### PR TITLE
Pack.png description error fix

### DIFF
--- a/MCatH/MCatH/packpng.html
+++ b/MCatH/MCatH/packpng.html
@@ -88,7 +88,7 @@
         <h1 class="u-text u-text-1">
           <span class="u-text-palette-4-light-2" style="">Pack.PNG</span>
         </h1>
-        <p class="u-large-text u-text u-text-variant u-text-2">The menu background image from Beta 1.8 through Release 1.13</p>
+        <p class="u-large-text u-text u-text-variant u-text-2">The world of the famous Pack.PNG icon.</p>
       </div>
     </section>
     <section class="u-clearfix u-section-2" id="sec-af45">


### PR DESCRIPTION
The pack.png page uses the Beta Panorama description in the top banner.
Changed it to "The world of the famous Pack.PNG icon." instead of "The menu background image from Beta 1.8 through Release 1.13"