### PR TITLE
Skull on Fire wrong description fix

### DIFF
--- a/MCatH/MCatH/skull-painting.html
+++ b/MCatH/MCatH/skull-painting.html
@@ -89,7 +89,7 @@
           <span class="u-text-palette-4-light-2"></span>
           <span class="u-text-palette-4-light-2" style="">Painting</span>
         </h1>
-        <p class="u-large-text u-text u-text-variant u-text-2">The menu background image from Beta 1.8 through Release 1.13</p>
+        <p class="u-large-text u-text u-text-variant u-text-2">The world in the background of the Skull on Fire painting.</p>
       </div>
     </section>
     <section class="u-clearfix u-section-2" id="sec-af45">


### PR DESCRIPTION
The Skull on Fire page has the description of the Beta Panorama in the top banner. 
Changed it to "The world in the background of the Skull on Fire painting." from "The menu background image from Beta 1.8 through Release 1.13"